### PR TITLE
Fix issue where IFTTT menu was not visible

### DIFF
--- a/src/collective/ifttt/browser/configure.zcml
+++ b/src/collective/ifttt/browser/configure.zcml
@@ -60,14 +60,14 @@
   <!-- Sub-menus -->
 
   <browser:menu
-    id="plone_contentmenu_iftttactions"
-    title="The 'actions' menu - allows the user to execute actions on an object"
+    id="plone_contentmenu_ifttttriggers"
+    title="The IFTTT - allows the user to configure IFTTT content rules on an object"
     class=".menu.IftttTriggersMenu"
     />
 
   <adapter for="* *"
-           name="plone.contentmenu.actions"
-           factory=".menu.IftttTriggerSubMenuItem"
-           provides=".interfaces.IContentMenuItem" />
+           name="plone.contentmenu.ifttttriggers"
+           factory=".menu.IftttTriggersSubMenuItem"
+           provides="plone.app.contentmenu.interfaces.IContentMenuItem" />
 
 </configure>

--- a/src/collective/ifttt/browser/interfaces.py
+++ b/src/collective/ifttt/browser/interfaces.py
@@ -1,40 +1,6 @@
 # -*- coding: utf-8 -*-
-
 from zope.browsermenu.interfaces import IBrowserMenu
 from zope.browsermenu.interfaces import IBrowserSubMenuItem
-from zope.browsermenu.interfaces import IMenuItemType
-from zope.contentprovider.interfaces import IContentProvider
-from zope.interface import Interface
-from zope.interface import provider
-
-
-class IContentMenuView(IContentProvider):
-    """The view that powers the content menu in the toolbar.
-
-    This will construct a menu by finding an adapter to IContentMenu.
-    """
-
-    def available():  # noqa
-        """Determine whether the menu should be displayed at all.
-        """
-
-    def menu():  # noqa
-        """Create a list of dicts that can be used to render a menu.
-
-        The keys in this dict are: title, description, action (a URL),
-        selected (a boolean), icon (a URI), extra (a random payload), and
-        submenu
-        """
-
-
-# The content menu itself - menu items are registered as adapters to this
-# interface (this is signalled by marking the interface itself with the
-# IInterface IMenuItemType)
-
-
-@provider(IMenuItemType)
-class IContentMenuItem(Interface):
-    """Special menu item type for Plone's content menu."""
 
 
 class IftttTriggerSubMenuItem(IBrowserSubMenuItem):

--- a/src/collective/ifttt/browser/menu.py
+++ b/src/collective/ifttt/browser/menu.py
@@ -67,7 +67,7 @@ class IftttTriggersMenu(BrowserMenu):
                 'selected': False,
                 'icon': icon,
                 'extra': {
-                    'id': 'plone-contentmenu-actions-' + aid,
+                    'id': 'plone-contentmenu-ifttttriggers-' + aid,
                     'separator': None,
                     'class': css_class,
                     'modal': modal,

--- a/src/collective/ifttt/browser/menu.py
+++ b/src/collective/ifttt/browser/menu.py
@@ -1,45 +1,33 @@
 # -*- coding: utf-8 -*-
-
 from collective.ifttt import _
 from collective.ifttt.browser.interfaces import IftttTriggersMenu
 from collective.ifttt.browser.interfaces import IftttTriggerSubMenuItem
-from plone.api.portal import get_tool
+from plone.app.contentmenu.menu import ActionsSubMenuItem
 from plone.memoize.instance import memoize
 from plone.protect.utils import addTokenToUrl
-# from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone import utils
 from zope.browsermenu.menu import BrowserMenu
-from zope.browsermenu.menu import BrowserSubMenuItem
 from zope.component import getMultiAdapter
 from zope.interface import implementer
 
+import plone.api as api
+
 
 @implementer(IftttTriggerSubMenuItem)
-class IftttTriggerSubMenuItem(BrowserSubMenuItem):
-
-    title = _(u'label_actions_menu', default=u'Actions')
-    description = _(
-        u'title_actions_menu', default=u'Actions for the current content item'
+class IftttTriggersSubMenuItem(ActionsSubMenuItem):
+    title = _(
+        u'label_ifttt_menu',
+        default=u'IFTTT',
     )
-    submenuId = 'plone_contentmenu_iftttactions'
-
-    order = 30
+    description = _(
+        u'title_ifttt_menu',
+        default=u'IFTTT trigger content rules for the current content item',
+    )
+    submenuId = 'plone_contentmenu_ifttttriggers'
+    order = 35
     extra = {
-        'id': 'plone-contentmenu-actions',
+        'id': 'plone-contentmenu-ifttttriggers',
         'li_class': 'plonetoolbar-content-action'
     }
-
-    def __init__(self, context, request):
-        super(IftttTriggerSubMenuItem, self).__init__(context, request)
-        self.context_state = getMultiAdapter((context, request),
-                                             name='plone_context_state')
-
-    @property
-    def action(self):
-        folder = self.context
-        if not self.context_state.is_structural_folder():
-            folder = utils.parent(self.context)
-        return folder.absolute_url() + '/folder_contents'
 
     @memoize
     def available(self):
@@ -47,10 +35,7 @@ class IftttTriggerSubMenuItem(BrowserSubMenuItem):
         actions = actions_tool.listActionInfos(
             object=self.context, categories=('object_ifttt_triggers', ), max=1
         )
-        return len(editActions) > 0
-
-    def selected(self):
-        return False
+        return len(actions) > 0
 
 
 @implementer(IftttTriggersMenu)
@@ -73,7 +58,7 @@ class IftttTriggersMenu(BrowserMenu):
             icon = action.get('icon', None)
             modal = action.get('modal', None)
             if modal:
-                cssClass += ' pat-plone-modal'
+                css_class += ' pat-plone-modal'
 
             results.append({
                 'title': action['title'],
@@ -84,8 +69,8 @@ class IftttTriggersMenu(BrowserMenu):
                 'extra': {
                     'id': 'plone-contentmenu-actions-' + aid,
                     'separator': None,
-                    'class': cssClass,
-                    'modal': modal
+                    'class': css_class,
+                    'modal': modal,
                 },
                 'submenu': None,
             })

--- a/src/collective/ifttt/browser/menu.py
+++ b/src/collective/ifttt/browser/menu.py
@@ -43,9 +43,9 @@ class IftttTriggerSubMenuItem(BrowserSubMenuItem):
 
     @memoize
     def available(self):
-        actions_tool = get_tool(self.context, 'portal_actions')
-        editActions = actions_tool.listActionInfos(
-            object=self.context, categories=('object_buttons', ), max=1
+        actions_tool = api.portal.get_tool('portal_actions')
+        actions = actions_tool.listActionInfos(
+            object=self.context, categories=('object_ifttt_triggers', ), max=1
         )
         return len(editActions) > 0
 
@@ -61,15 +61,15 @@ class IftttTriggersMenu(BrowserMenu):
 
         context_state = getMultiAdapter((context, request),
                                         name='plone_context_state')
-        editActions = context_state.actions('object_buttons')
-        if not editActions:
+        actions = context_state.actions('object_ifttt_triggers')
+        if not actions:
             return results
 
-        for action in editActions:
+        for action in actions:
             if not action['allowed']:
                 continue
             aid = action['id']
-            cssClass = 'actionicon-object_buttons-{0}'.format(aid)
+            css_class = 'actionicon-object_ifttt_triggers-{0}'.format(aid)
             icon = action.get('icon', None)
             modal = action.get('modal', None)
             if modal:

--- a/src/collective/ifttt/profiles/default/actions.xml
+++ b/src/collective/ifttt/profiles/default/actions.xml
@@ -1,42 +1,80 @@
 <?xml version="1.0"?>
 <object name="portal_actions" meta_type="Plone Actions Tool"
-   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
- <object name="object_buttons" meta_type="CMF Action Category">
-  <object name="Add IFTTT Content Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
-   <property name="title" i18n:translate="">Add IFTTT Content Trigger</property>
-   <property name="description" i18n:translate="">Add new IFTTT Content Trigger</property>
-   <property name="url_expr">string:$object_url/@@ifttt_content_trigger</property>
-   <property name="icon_expr"></property>
-   <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
-   <property name="permissions">
-      <element value="Content rules: Manage rules"/>
-      <element value="Plone Site Setup: IFTTT"/>
-   </property>
-   <property name="visible">True</property>
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <object name="object_buttons" meta_type="CMF Action Category">
+    <object name="Add IFTTT Content Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
+      <property name="title" i18n:translate="">Add IFTTT Content Trigger</property>
+      <property name="description" i18n:translate="">Add new IFTTT Content Trigger</property>
+      <property name="url_expr">string:$object_url/@@ifttt_content_trigger</property>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
+      <property name="permissions">
+        <element value="Content rules: Manage rules"/>
+        <element value="Plone Site Setup: IFTTT"/>
+      </property>
+      <property name="visible">False</property>
+    </object>
+    <object name="Add IFTTT User Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
+      <property name="title" i18n:translate="">Add IFTTT User Trigger</property>
+      <property name="description" i18n:translate="">Add new IFTTT User Trigger</property>
+      <property name="url_expr">string:$object_url/@@ifttt_user_trigger</property>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
+      <property name="permissions">
+        <element value="Content rules: Manage rules"/>
+        <element value="Plone Site Setup: IFTTT"/>
+      </property>
+      <property name="visible">False</property>
+    </object>
+    <object name="Add IFTTT Event Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
+      <property name="title" i18n:translate="">Add IFTTT Event Trigger</property>
+      <property name="description" i18n:translate="">Add new IFTTT Event Trigger</property>
+      <property name="url_expr">string:$object_url/@@ifttt_event_trigger</property>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
+      <property name="permissions">
+        <element value="Content rules: Manage rules"/>
+        <element value="Plone Site Setup: IFTTT"/>
+      </property>
+      <property name="visible">False</property>
+    </object>
   </object>
-  <object name="Add IFTTT User Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
-   <property name="title" i18n:translate="">Add IFTTT User Trigger</property>
-   <property name="description" i18n:translate="">Add new IFTTT User Trigger</property>
-   <property name="url_expr">string:$object_url/@@ifttt_user_trigger</property>
-   <property name="icon_expr"></property>
-   <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
-   <property name="permissions">
-      <element value="Content rules: Manage rules"/>
-      <element value="Plone Site Setup: IFTTT"/>
-   </property>
-   <property name="visible">True</property>
+  <object name="object_ifttt_triggers" meta_type="CMF Action Category">
+    <object name="Add IFTTT Content Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
+      <property name="title" i18n:translate="">Add IFTTT Content Trigger</property>
+      <property name="description" i18n:translate="">Add new IFTTT Content Trigger</property>
+      <property name="url_expr">string:$object_url/@@ifttt_content_trigger</property>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
+      <property name="permissions">
+        <element value="Content rules: Manage rules"/>
+        <element value="Plone Site Setup: IFTTT"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <object name="Add IFTTT User Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
+      <property name="title" i18n:translate="">Add IFTTT User Trigger</property>
+      <property name="description" i18n:translate="">Add new IFTTT User Trigger</property>
+      <property name="url_expr">string:$object_url/@@ifttt_user_trigger</property>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
+      <property name="permissions">
+        <element value="Content rules: Manage rules"/>
+        <element value="Plone Site Setup: IFTTT"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <object name="Add IFTTT Event Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
+      <property name="title" i18n:translate="">Add IFTTT Event Trigger</property>
+      <property name="description" i18n:translate="">Add new IFTTT Event Trigger</property>
+      <property name="url_expr">string:$object_url/@@ifttt_event_trigger</property>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
+      <property name="permissions">
+        <element value="Content rules: Manage rules"/>
+        <element value="Plone Site Setup: IFTTT"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
   </object>
-  <object name="Add IFTTT Event Trigger" meta_type="CMF Action" i18n:domain="collective.ifttt">
-   <property name="title" i18n:translate="">Add IFTTT Event Trigger</property>
-   <property name="description" i18n:translate="">Add new IFTTT Event Trigger</property>
-   <property name="url_expr">string:$object_url/@@ifttt_event_trigger</property>
-   <property name="icon_expr"></property>
-   <property name="available_expr">python:path('object/@@checkifttt').check_iftttconfig()</property>
-   <property name="permissions">
-      <element value="Content rules: Manage rules"/>
-      <element value="Plone Site Setup: IFTTT"/>
-   </property>
-   <property name="visible">True</property>
-  </object>
- </object>
 </object>

--- a/src/collective/ifttt/profiles/default/metadata.xml
+++ b/src/collective/ifttt/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1009</version>
+  <version>1010</version>
   <dependencies>
     <!--<dependency>profile-plone.app.dexterity:default</dependency></dependencies>-->
   </dependencies>

--- a/src/collective/ifttt/tests/robot/test_content_trigger.robot
+++ b/src/collective/ifttt/tests/robot/test_content_trigger.robot
@@ -85,13 +85,13 @@ I goto home page
 # --- WHEN -------------------------------------------------------------------
 
 I check the 'Add IFTTT Content Trigger' action menu item
-    Element should not be visible  xpath=//li[@id='plone-contentmenu-actions']/a
+    Element should not be visible  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
 
 I trigger the '${action}' action menu item
-    Element should be visible  xpath=//li[@id='plone-contentmenu-actions']/a
-    Click link  xpath=//li[@id='plone-contentmenu-actions']/a
-    Wait until element is visible  id=plone-contentmenu-actions-${action}
-    Click link  id=plone-contentmenu-actions-${action}
+    Element should be visible  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
+    Click link  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
+    Wait until element is visible  id=plone-contentmenu-ifttttriggers-${action}
+    Click link  id=plone-contentmenu-ifttttriggers-${action}
 
 I fill Content Trigger form
    input 'test_event' into 'form-widgets-ifttt_event_name' textinput

--- a/src/collective/ifttt/tests/robot/test_event_trigger.robot
+++ b/src/collective/ifttt/tests/robot/test_event_trigger.robot
@@ -85,13 +85,13 @@ I goto home page
 # --- WHEN -------------------------------------------------------------------
 
 I check the 'Add IFTTT Event Trigger' action menu item
-    Element should not be visible  xpath=//li[@id='plone-contentmenu-actions']/a
+    Element should not be visible  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
 
 I trigger the '${action}' action menu item
-    Element should be visible  xpath=//li[@id='plone-contentmenu-actions']/a
-    Click link  xpath=//li[@id='plone-contentmenu-actions']/a
-    Wait until element is visible  id=plone-contentmenu-actions-${action}
-    Click link  id=plone-contentmenu-actions-${action}
+    Element should be visible  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
+    Click link  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
+    Wait until element is visible  id=plone-contentmenu-ifttttriggers-${action}
+    Click link  id=plone-contentmenu-ifttttriggers-${action}
 
 I fill Content Trigger form
    input 'test_event' into 'form-widgets-ifttt_event_name' textinput

--- a/src/collective/ifttt/tests/robot/test_user_trigger.robot
+++ b/src/collective/ifttt/tests/robot/test_user_trigger.robot
@@ -85,13 +85,13 @@ I goto home page
 # --- WHEN -------------------------------------------------------------------
 
 I check the 'Add IFTTT User Trigger' action menu item
-    Element should not be visible  xpath=//li[@id='plone-contentmenu-actions']/a
+    Element should not be visible  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
 
 I trigger the '${action}' action menu item
-    Element should be visible  xpath=//li[@id='plone-contentmenu-actions']/a
-    Click link  xpath=//li[@id='plone-contentmenu-actions']/a
-    Wait until element is visible  id=plone-contentmenu-actions-${action}
-    Click link  id=plone-contentmenu-actions-${action}
+    Element should be visible  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
+    Click link  xpath=//li[@id='plone-contentmenu-ifttttriggers']/a
+    Wait until element is visible  id=plone-contentmenu-ifttttriggers-${action}
+    Click link  id=plone-contentmenu-ifttttriggers-${action}
 
 I fill Content Trigger form
    input 'test_event' into 'form-widgets-ifttt_event_name' textinput

--- a/src/collective/ifttt/upgrades.zcml
+++ b/src/collective/ifttt/upgrades.zcml
@@ -4,7 +4,7 @@
 
   <genericsetup:upgradeStep
     source="*"
-    destination="1009"
+    destination="1010"
     title="Reload GS profiles"
     description=""
     profile="collective.ifttt:default"


### PR DESCRIPTION
@Shriyanshagro 

The first commit in this pull was the reason why your new menu was not visible. You accidentally copied also the interface that was supposed to link the menu adapters with "Plone content menu".

https://github.com/collective/collective.ifttt/commit/51c1f472d9a0cc399b730e14461d02db795773bd

I cannot blame you on this, because this whole menu framework is very well documented (well, it is documented in "Zope 3 framework" book, but its integration with Plone not so much).

The third commit disables the current IFTTT items in action menu and creates a new action group connected to IFTTT menu. It allows us to populate IFTTT menu from actions.xml:

https://github.com/collective/collective.ifttt/commit/affe60a6a8e83cb47193c0ef6f1b84be73926d1f

The second and last commit are mostly just clean up.